### PR TITLE
resume download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
 dependencies = [
- "nix",
+ "nix 0.27.1",
  "rand 0.8.5",
 ]
 
@@ -1618,6 +1618,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
+dependencies = [
+ "nix 0.28.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,6 +2441,7 @@ dependencies = [
  "clap",
  "confy 0.6.0",
  "criterion",
+ "ctrlc",
  "derive-getters",
  "dotenv",
  "ethers",
@@ -4090,6 +4101,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 

--- a/docs/client_guide.md
+++ b/docs/client_guide.md
@@ -53,7 +53,8 @@ $ file-exchange downloader \
    --network-subgraph https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-arbitrum-sepolia \
    --escrow-subgraph https://api.thegraph.com/subgraphs/name/graphprotocol/scalar-tap-arbitrum-sepolia \
    --provider-concurrency 2 \
-   local-files --main-dir "../example-download"
+   --progress-file "../example-download" \
+   local-files --main-dir "../example-file"
 ```
 
 Download into remote object storage bucket with paid query flow
@@ -79,7 +80,7 @@ $ file-exchange downloader \
 ### Getting Started
 
 1. You can use the provided binaries, docker image, or download and install the source code.
-2. Gather configurations as described in the above Requirements section.
+2. Gather configurations as described in the above Requirements section. For detailed CLI instructions, run `file-exchange donwloader --help`.
 3. Use the CLI commands to download files.
 
 Before downloading, the client will check the status and price of the providers. If the download can be achived by availablility and price at the time of initiation, then download will proceed. 

--- a/file-exchange/Cargo.toml
+++ b/file-exchange/Cargo.toml
@@ -29,6 +29,7 @@ bytes = "1.0"
 chrono = "0.4.31"
 clap = { version = "4.4", features = ["cargo", "unstable-doc"] }
 confy = "0.6"
+ctrlc = "3.4.4"
 derive-getters = "0.3.0"
 dotenv = "0.15"
 ethers = "2.0.11"

--- a/file-exchange/src/config.rs
+++ b/file-exchange/src/config.rs
@@ -287,6 +287,13 @@ pub struct DownloaderArgs {
         help = "Maximum GRT configured for automatic deposit (Used for GraphToken approval to Escrow contract and across Escrow accounts"
     )]
     pub max_auto_deposit: f64,
+    #[clap(
+        long,
+        value_name = "PROGRESS_CACHE",
+        env = "PROGRESS_CACHE",
+        help = "Json file to store progress if download fails; read the file to resume download if the file is nonempty"
+    )]
+    pub progress_cache: Option<String>,
 }
 
 /// Publisher takes the files, generate bundle manifest, and publish to IPFS

--- a/file-exchange/src/config.rs
+++ b/file-exchange/src/config.rs
@@ -293,7 +293,7 @@ pub struct DownloaderArgs {
         env = "PROGRESS_CACHE",
         help = "Json file to store progress if download fails; read the file to resume download if the file is nonempty"
     )]
-    pub progress_cache: Option<String>,
+    pub progress_file: Option<String>,
 }
 
 /// Publisher takes the files, generate bundle manifest, and publish to IPFS

--- a/file-exchange/src/download_client/mod.rs
+++ b/file-exchange/src/download_client/mod.rs
@@ -118,8 +118,8 @@ impl Downloader {
 
         let store = Store::new(&args.storage_method).expect("Create store");
 
-        let target_chunks = if let Some(cache) = &args.progress_cache {
-            let map = read_json_to_map(cache).expect("Progress cache ill-formatted");
+        let target_chunks = if let Some(file_path) = &args.progress_file {
+            let map = read_json_to_map(&file_path).expect("Progress cache ill-formatted");
             Arc::new(StdMutex::new(map))
         } else {
             Arc::new(StdMutex::new(HashMap::new()))
@@ -154,9 +154,9 @@ impl Downloader {
 
     /// Read manifest to prepare chunks download
     pub fn init_target_chunks(&self, bundle: &Bundle) {
-        if let Some(cache) = &self.config.progress_cache {
+        if let Some(file_path) = &self.config.progress_file {
             let mut target_chunks = self.target_chunks.lock().unwrap();
-            *target_chunks = read_json_to_map(cache).expect("Progress cache ill-formatted");
+            *target_chunks = read_json_to_map(&file_path).expect("Progress cache ill-formatted");
         }
         for file_manifest_meta in &bundle.file_manifests {
             let mut target_chunks = self.target_chunks.lock().unwrap();
@@ -206,8 +206,8 @@ impl Downloader {
             );
             tracing::warn!(msg);
             // store progress into a json file: {hash: missing_chunk_indices}
-            if let Some(cache_loc) = &self.config.progress_cache {
-                store_map_as_json(&incomplete_progresses, cache_loc)?;
+            if let Some(file_path) = &self.config.progress_file {
+                store_map_as_json(&incomplete_progresses, &file_path)?;
             };
             return Err(Error::DataUnavailable(msg));
         } else {

--- a/file-exchange/src/main.rs
+++ b/file-exchange/src/main.rs
@@ -26,11 +26,11 @@ async fn main() {
                 config = tracing::field::debug(&config),
                 "Downloader request"
             );
-            let progress_cache = config.progress_cache.clone();
+            let progress_file = config.progress_file.clone();
             // Create client
             let downloader = Downloader::new(client, config).await;
 
-            if let Some(cache) = progress_cache {
+            if let Some(cache) = progress_file {
                 let chunks = downloader.target_chunks.clone();
                 ctrlc::set_handler(move || {
                     tracing::info!("CTRL+C pressed. Store progress cache to json");

--- a/file-exchange/tests/file_transfer.rs
+++ b/file-exchange/tests/file_transfer.rs
@@ -51,6 +51,7 @@ mod tests {
             mnemonic: None,
             free_query_auth_token: Some("Bearer free-token".to_string()),
             provider: None,
+            provider_concurrency: 2,
             ..Default::default()
         };
 

--- a/file-exchange/tests/file_transfer.rs
+++ b/file-exchange/tests/file_transfer.rs
@@ -51,7 +51,6 @@ mod tests {
             mnemonic: None,
             free_query_auth_token: Some("Bearer free-token".to_string()),
             provider: None,
-            provider_concurrency: 2,
             ..Default::default()
         };
 


### PR DESCRIPTION
### Description
A user can optionally provide a file path to store download progress in case of failure and early cut-off. The progress is stored in a json file, in which an inner option is the map of file manifest ipfs hash to the missing chunk indices. 
Progress gets stored when a file ran out of maximum attempt and there's no available indexers, or when user presses ctrl+c. 
With this file, the downloader can continue downloading from a previous session. 

### Issue link (if applicable)
Resolves #32 

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
